### PR TITLE
Revert sklearn flag changes 

### DIFF
--- a/models/totalsegmentator/dockerfiles/cuda11.4/Dockerfile
+++ b/models/totalsegmentator/dockerfiles/cuda11.4/Dockerfile
@@ -1,6 +1,13 @@
 # Specify the base image for the environment
 FROM mhubai/base:cuda11.4
 
+# FIXME: set this environment variable as a shortcut to avoid nnunet crashing the build
+# by pulling sklearn instead of scikit-learn
+# N.B. this is a known issue:
+# https://github.com/MIC-DKFZ/nnUNet/issues/1281 
+# https://github.com/MIC-DKFZ/nnUNet/pull/1209
+ENV SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True
+
 # Install TotalSegmentator
 RUN pip3 install --no-cache-dir TotalSegmentator 
 

--- a/models/totalsegmentator/dockerfiles/cuda12.0/Dockerfile
+++ b/models/totalsegmentator/dockerfiles/cuda12.0/Dockerfile
@@ -1,6 +1,13 @@
 # Specify the base image for the environment
 FROM mhubai/base:cuda12.0
 
+# FIXME: set this environment variable as a shortcut to avoid nnunet crashing the build
+# by pulling sklearn instead of scikit-learn
+# N.B. this is a known issue:
+# https://github.com/MIC-DKFZ/nnUNet/issues/1281 
+# https://github.com/MIC-DKFZ/nnUNet/pull/1209
+ENV SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True
+
 # Install TotalSegmentator
 RUN pip3 install --no-cache-dir TotalSegmentator 
 

--- a/models/totalsegmentator/dockerfiles/nocuda/Dockerfile
+++ b/models/totalsegmentator/dockerfiles/nocuda/Dockerfile
@@ -1,6 +1,13 @@
 # Specify the base image for the environment
 FROM mhubai/base:nocuda
 
+# FIXME: set this environment variable as a shortcut to avoid nnunet crashing the build
+# by pulling sklearn instead of scikit-learn
+# N.B. this is a known issue:
+# https://github.com/MIC-DKFZ/nnUNet/issues/1281 
+# https://github.com/MIC-DKFZ/nnUNet/pull/1209
+ENV SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True
+
 # Install TotalSegmentator
 RUN pip3 install --no-cache-dir TotalSegmentator 
 


### PR DESCRIPTION
TotalSegmentator still relies on an older version of nnunet and thus still need the following in the dockerfile:

```
# FIXME: set this environment variable as a shortcut to avoid nnunet crashing the build
# by pulling sklearn instead of scikit-learn
# N.B. this is a known issue:
# https://github.com/MIC-DKFZ/nnUNet/issues/1281 
# https://github.com/MIC-DKFZ/nnUNet/pull/1209
ENV SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True
```