### PR TITLE
install dcm2niix in all base images

### DIFF
--- a/base/dockerfiles/cuda11.4/Dockerfile
+++ b/base/dockerfiles/cuda11.4/Dockerfile
@@ -25,6 +25,7 @@ RUN apt update && apt install -y --no-install-recommends \
   python3 \
   python3-pip \
   plastimatch \
+  dcm2niix \
   && rm -rf /var/lib/apt/lists/* \
   && apt update && apt install -y ffmpeg libsm6 libxext6 xvfb
 

--- a/base/dockerfiles/cuda12.0/Dockerfile
+++ b/base/dockerfiles/cuda12.0/Dockerfile
@@ -25,6 +25,7 @@ RUN apt update && apt install -y --no-install-recommends \
   python3 \
   python3-pip \
   plastimatch \
+  dcm2niix \
   && rm -rf /var/lib/apt/lists/* \
   && apt update && apt install -y ffmpeg libsm6 libxext6 xvfb
 

--- a/base/dockerfiles/nocuda/Dockerfile
+++ b/base/dockerfiles/nocuda/Dockerfile
@@ -25,6 +25,7 @@ RUN apt update && apt install -y --no-install-recommends \
   python3 \
   python3-pip \
   plastimatch \
+  dcm2niix \
   && rm -rf /var/lib/apt/lists/* \
   && apt update && apt install -y ffmpeg libsm6 libxext6 xvfb
 


### PR DESCRIPTION
Add `apt install -y --no-install-recommends dcm2niix` in all three base images (nocuda, cuda11.4, cuda12.0).