### PR TITLE
add python type_extension to all base images

### DIFF
--- a/base/dockerfiles/cuda11.4/Dockerfile
+++ b/base/dockerfiles/cuda11.4/Dockerfile
@@ -36,6 +36,7 @@ WORKDIR /app
 
 # Install general utilities (specify version if necessary)
 RUN pip3 install --upgrade pip && pip3 install --no-cache-dir \
+  typing-extensions \
   albumentations \
   h5py \
   nibabel \ 

--- a/base/dockerfiles/cuda12.0/Dockerfile
+++ b/base/dockerfiles/cuda12.0/Dockerfile
@@ -36,6 +36,7 @@ WORKDIR /app
 
 # Install general utilities (specify version if necessary)
 RUN pip3 install --upgrade pip && pip3 install --no-cache-dir \
+  typing-extensions \
   albumentations \
   h5py \
   nibabel \ 

--- a/base/dockerfiles/nocuda/Dockerfile
+++ b/base/dockerfiles/nocuda/Dockerfile
@@ -36,6 +36,7 @@ WORKDIR /app
 
 # Install general utilities (specify version if necessary)
 RUN pip3 install --upgrade pip && pip3 install --no-cache-dir \
+  typing-extensions \
   albumentations \
   h5py \
   nibabel \ 


### PR DESCRIPTION
Adding `pip3 install typing-extensions` adding backported and experimental type hints for Python 3.7+.