### PR TITLE
BUG: make values assigned to BodyPartExamined compliant with DICOM

### DIFF
--- a/models/lungmask/config/dseg.json
+++ b/models/lungmask/config/dseg.json
@@ -5,7 +5,7 @@
   "SeriesDescription": "Segmentation",
   "SeriesNumber": "42",
   "InstanceNumber": "1",
-  "BodyPartExamined": "Chest",
+  "BodyPartExamined": "CHEST",
   "segmentAttributes": [
     [
       {

--- a/models/nnunet_liver/config/meta.json
+++ b/models/nnunet_liver/config/meta.json
@@ -5,7 +5,7 @@
     "SeriesDescription": "Segmentation",
     "SeriesNumber": "42",
     "InstanceNumber": "1",
-    "BodyPartExamined": "Abdomen",
+    "BodyPartExamined": "ABDOMEN",
     "segmentAttributes": [
       [
         {

--- a/models/nnunet_pancreas/config/dseg.json
+++ b/models/nnunet_pancreas/config/dseg.json
@@ -5,7 +5,7 @@
     "SeriesDescription": "Segmentation",
     "SeriesNumber": "42",
     "InstanceNumber": "1",
-    "BodyPartExamined": "Abdomen",
+    "BodyPartExamined": "ABDOMEN",
     "segmentAttributes": [
       [
         {

--- a/models/platipy/config/dicomseg_metadata.json
+++ b/models/platipy/config/dicomseg_metadata.json
@@ -5,7 +5,7 @@
   "SeriesDescription": "Segmentation",
   "SeriesNumber": "42",
   "InstanceNumber": "1",
-  "BodyPartExamined": "Chest",
+  "BodyPartExamined": "CHEST",
   "segmentAttributes": [
     [
       {

--- a/models/totalsegmentator/config/dicomseg_metadata_cardiac.json
+++ b/models/totalsegmentator/config/dicomseg_metadata_cardiac.json
@@ -5,7 +5,7 @@
   "SeriesDescription": "Segmentation",
   "SeriesNumber": "42",
   "InstanceNumber": "1",
-  "BodyPartExamined": "Chest",
+  "BodyPartExamined": "CHEST",
   "segmentAttributes": [
     [
       {


### PR DESCRIPTION
BodyPartExamined content should be populated from the list of defined terms available in this table in the standard:

https://dicom.nema.org/medical/dicom/current/output/chtml/part16/chapter_L.html#chapter_L

Capitalization is important, since BodyPartExamined Value Representation (VR) is Code String (CS) (https://dicom.nema.org/medical/dicom/current/output/chtml/part05/sect_6.2.html), which does not allow lower case characters.