### PR TITLE
MHub / GC - WIP: Adding PanImg dataconverter classes for Xie lobe segmentation

### DIFF
--- a/models/xie2020_lobe_segmentation/config/config.yml
+++ b/models/xie2020_lobe_segmentation/config/config.yml
@@ -2,7 +2,6 @@ general:
   data_base_dir: /app/data
   
 modules:
-
   DicomImporter:
     source_dir: input_data
     import_dir: sorted_data
@@ -15,3 +14,5 @@ modules:
   DsegConverter:
     dicomseg_json_path: /app/models/xie2020_lobe_segmentation/config/dseg.json
     skip_empty_slices: True
+    body_part_examined: LUNG
+    source_segs: ['mha:mod=seg:roi=*']

--- a/models/xie2020_lobe_segmentation/dockerfiles/cuda11.4/Dockerfile
+++ b/models/xie2020_lobe_segmentation/dockerfiles/cuda11.4/Dockerfile
@@ -9,6 +9,12 @@ RUN pip3 install --no-cache-dir \
     dgl-cu113 -f https://data.dgl.ai/wheels/repo.html \
     torch==1.10.0+cu113 torchvision==0.11.1+cu113 -f https://download.pytorch.org/whl/cu113/torch_stable.html
 
+# Install panimg to test conversion integration TODO should later be installed with MHub/mhubio
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  python3-openslide \
+  && rm -rf /var/lib/apt/lists/*
+RUN pip3 install panimg
+
 # SimpleITK downgrade required for legacy Resample::Execute operation
 RUN pip3 install --no-cache-dir --force-reinstall SimpleITK==1.2.4
 

--- a/models/xie2020_lobe_segmentation/dockerfiles/cuda11.4/Dockerfile
+++ b/models/xie2020_lobe_segmentation/dockerfiles/cuda11.4/Dockerfile
@@ -2,7 +2,7 @@
 FROM mhubai/base:cuda11.4
 
 # Specify/override authors label
-LABEL authors="s.vandeleemput@radboudumc.nl"
+LABEL authors="sil.vandeleemput@radboudumc.nl"
 
 # install required dependencies for lobe segmentation (CUDA-enabled)
 RUN pip3 install --no-cache-dir \

--- a/models/xie2020_lobe_segmentation/dockerfiles/nocuda/Dockerfile
+++ b/models/xie2020_lobe_segmentation/dockerfiles/nocuda/Dockerfile
@@ -9,6 +9,12 @@ RUN pip3 install --no-cache-dir \
     dgl===1.0.2 -f https://data.dgl.ai/wheels/repo.html \
     torch===1.9.0+cpu torchvision==0.10.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
 
+# Install panimg to test conversion integration TODO should later be installed with MHub/mhubio
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  python3-openslide \
+  && rm -rf /var/lib/apt/lists/*
+RUN pip3 install panimg
+
 # SimpleITK downgrade required for legacy Resample::Execute operation
 RUN pip3 install --no-cache-dir --force-reinstall SimpleITK==1.2.4
 

--- a/models/xie2020_lobe_segmentation/dockerfiles/nocuda/Dockerfile
+++ b/models/xie2020_lobe_segmentation/dockerfiles/nocuda/Dockerfile
@@ -2,7 +2,7 @@
 FROM mhubai/base:nocuda
 
 # Specify/override authors label
-LABEL authors="s.vandeleemput@radboudumc.nl"
+LABEL authors="sil.vandeleemput@radboudumc.nl"
 
 # install required dependencies for lobe segmentation (CPU-only)
 RUN pip3 install --no-cache-dir \

--- a/models/xie2020_lobe_segmentation/scripts/run.py
+++ b/models/xie2020_lobe_segmentation/scripts/run.py
@@ -5,7 +5,7 @@ MHub / DIAG - Run Xie2020 Lobe Segmentation locally
 
 ---------------------------------------------------
 Author: Sil van de Leemput
-Email:  s.vandeleemput@radboudumc.nl
+Email:  sil.vandeleemput@radboudumc.nl
 ---------------------------------------------------
 """
 

--- a/models/xie2020_lobe_segmentation/scripts/run.py
+++ b/models/xie2020_lobe_segmentation/scripts/run.py
@@ -19,6 +19,7 @@ from mhubio.modules.convert.NiftiConverter import NiftiConverter
 from mhubio.modules.convert.DsegConverter import DsegConverter
 from mhubio.modules.organizer.DataOrganizer import DataOrganizer
 from models.xie2020_lobe_segmentation.utils.LobeSegmentationRunner import LobeSegmentationRunner
+from models.xie2020_lobe_segmentation.utils.PanImgConverters import MhaPanImgConverter
 
 # clean-up
 import shutil
@@ -32,13 +33,13 @@ config = Config('/app/models/xie2020_lobe_segmentation/config/config.yml')
 # import (ct:dicom)
 DicomImporter(config).execute()
 
-# convert (ct:dicom -> ct:nrrd)
-NrrdConverter(config).execute()
+# convert (ct:dicom -> ct:mha)
+MhaPanImgConverter(config).execute()
 
 # execute model (nnunet)
 LobeSegmentationRunner(config).execute()
 
-# convert (seg:nifti -> seg:dicomseg)
+# convert (seg:mha -> seg:dicomseg)
 DsegConverter(config).execute()
 
 # organize data into output folder

--- a/models/xie2020_lobe_segmentation/scripts/slicer_run.py
+++ b/models/xie2020_lobe_segmentation/scripts/slicer_run.py
@@ -16,6 +16,7 @@ from mhubio.core import Config, DataType, FileType, SEG
 from mhubio.modules.importer.NrrdImporter import NrrdImporter
 from mhubio.modules.organizer.DataOrganizer import DataOrganizer
 from models.xie2020_lobe_segmentation.utils.LobeSegmentationRunner import LobeSegmentationRunner
+from models.xie2020_lobe_segmentation.utils.PanImgConverters import MhaPanImgConverter
 
 # config
 config = Config('/app/models/xie2020_lobe_segmentation/config/slicer_config.yml')
@@ -23,10 +24,15 @@ config = Config('/app/models/xie2020_lobe_segmentation/config/slicer_config.yml'
 # load NRRD file (ct:nrrd)
 NrrdImporter(config).execute()
 
-# execute model (ct:nrrd -> seg:nrrd)
+# convert (ct:nrrd -> ct:mha)
+MhaPanImgConverter(config).execute()
+
+# execute model (ct:mha -> seg:mha)
 LobeSegmentationRunner(config).execute()
+
+# TODO should probably be converted back to NRRD here...
 
 # organize data into output folder
 organizer = DataOrganizer(config, set_file_permissions=sys.platform.startswith('linux'))
-organizer.setTarget(DataType(FileType.NRRD, SEG), "/app/data/output_data/xie2020lobeseg.nrrd")
+organizer.setTarget(DataType(FileType.MHA, SEG), "/app/data/output_data/xie2020lobeseg.mha")
 organizer.execute()

--- a/models/xie2020_lobe_segmentation/scripts/slicer_run.py
+++ b/models/xie2020_lobe_segmentation/scripts/slicer_run.py
@@ -5,7 +5,7 @@ MHub / DIAG - Slicer run for Xie2020 Lobe Segmentation
 
 ------------------------------------------------------
 Author: Sil van de Leemput
-Email:  s.vandeleemput@radboudumc.nl
+Email:  sil.vandeleemput@radboudumc.nl
 ------------------------------------------------------
 """
 

--- a/models/xie2020_lobe_segmentation/utils/LobeSegmentationRunner.py
+++ b/models/xie2020_lobe_segmentation/utils/LobeSegmentationRunner.py
@@ -20,10 +20,9 @@ from test import segment_lobe, segment_lobe_init
 class LobeSegmentationRunner(Module):
 
     @IO.Instance()
-    @IO.Input('in_data', 'nrrd:mod=ct', the='input ct scan')
-    @IO.Output('out_data', 'xie2020lobeseg.nrrd', 'nrrd:mod=seg:model=Xie2020LobeSegmentation', 'in_data', the='predicted segmentation of the lung lobes')
+    @IO.Input('in_data', 'mha:mod=ct', the='input ct scan')
+    @IO.Output('out_data', 'xie2020lobeseg.mha', 'mha:mod=seg:model=Xie2020LobeSegmentation', 'in_data', the='predicted segmentation of the lung lobes')
     def task(self, instance: Instance, in_data: InstanceData, out_data: InstanceData) -> None:
-        # NOTE input data originally was specified for MHA/MHD and could be extended for DICOM
 
         # read image
         self.v(f"Reading image from {in_data.abspath}")

--- a/models/xie2020_lobe_segmentation/utils/LobeSegmentationRunner.py
+++ b/models/xie2020_lobe_segmentation/utils/LobeSegmentationRunner.py
@@ -5,7 +5,7 @@ Mhub / DIAG - Run Module for Xie2020 Lobe Segmentation
 
 ------------------------------------------------------
 Author: Sil van de Leemput
-Email:  s.vandeleemput@radboudumc.nl
+Email:  sil.vandeleemput@radboudumc.nl
 ------------------------------------------------------
 """
 

--- a/models/xie2020_lobe_segmentation/utils/PanImgConverters.py
+++ b/models/xie2020_lobe_segmentation/utils/PanImgConverters.py
@@ -1,0 +1,122 @@
+"""
+-------------------------------------------------------------
+MHub - PanImg Conversion Modules Dicom2Mha and WSI-Dicom2Tiff
+-------------------------------------------------------------
+
+-------------------------------------------------------------
+Author: Sil van de Leemput
+Email:  sil.vandeleemput@radboudumc.nl
+-------------------------------------------------------------
+"""
+
+
+from typing import Optional
+
+from mhubio.modules.convert.DataConverter import DataConverter
+from mhubio.core import Instance, InstanceData, DataType, FileType
+
+import os
+from pathlib import Path
+import shutil
+
+from panimg.exceptions import UnconsumedFilesException
+from panimg.image_builders.dicom import image_builder_dicom
+from panimg.image_builders.tiff import image_builder_tiff
+from panimg.image_builders.metaio_nrrd import image_builder_nrrd
+
+import SimpleITK
+
+
+class MhaPanImgConverter(DataConverter):
+    """
+    Conversion module.
+    Convert instance data from dicom or nrrd to mha.
+    """
+
+    def convert(self, instance: Instance) -> Optional[InstanceData]:
+
+        # create a converted instance
+        has_instance_dicom = instance.hasType(DataType(FileType.DICOM))
+        has_instance_nrrd = instance.hasType(DataType(FileType.NRRD))
+
+        assert has_instance_dicom or has_instance_nrrd, f"CONVERT ERROR: required datatype (dicom or nrrd) not available in instance {str(instance)}."
+
+        # select input data, dicom has priority over nrrd
+        input_data = instance.data.filter(DataType(FileType.DICOM) if has_instance_dicom else DataType(FileType.NRRD)).first()
+
+        # out data
+        mha_data = InstanceData("image.mha", DataType(FileType.MHA, input_data.type.meta))
+        mha_data.instance = instance
+
+        # paths
+        inp_data_dir = Path(input_data.abspath)
+        out_mha_file = Path(mha_data.abspath)
+
+        # sanity check
+        assert(inp_data_dir.is_dir())
+
+        # DICOM CT to MHA conversion (if the file doesn't exist yet)
+        if out_mha_file.is_file():
+            print("CONVERT ERROR: File already exists: ", out_mha_file)
+            return None
+        else:
+            # run conversion using panimg
+            input_files = {f for f in inp_data_dir.glob(["*.nrrd", "*.dcm"][has_instance_dicom]) if f.is_file()}
+            img_builder = image_builder_dicom if has_instance_dicom else image_builder_nrrd
+            try:
+                for result in img_builder(files=input_files):
+                    sitk_image = result.image  # SimpleITK image
+                    SimpleITK.WriteImage(sitk_image, str(out_mha_file))
+            except UnconsumedFilesException as e:
+                # e.errors is keyed with a Path to a file that could not be consumed,
+                # with a list of all the errors found with loading it,
+                # the user can then choose what to do with that information
+                print("CONVERT ERROR: UnconsumedFilesException during PanImg conversion: ", e.errors)
+                return None
+
+            return mha_data
+
+
+class TiffPanImgConverter(DataConverter):
+    """
+    Conversion module.
+    Convert instance data from WSI-dicom to tiff.
+    """
+
+    def convert(self, instance: Instance) -> Optional[InstanceData]:
+
+        # create a converted instance
+        assert instance.hasType(DataType(FileType.DICOM)), f"CONVERT ERROR: required datatype (dicom) not available in instance {str(instance)}."
+        dicom_data = instance.data.filter(DataType(FileType.DICOM)).first()
+
+        # out data
+        tiff_data = InstanceData("image.tiff", DataType(FileType.TIFF, dicom_data.type.meta))
+        tiff_data.instance = instance
+
+        # paths
+        inp_dicom_dir = Path(dicom_data.abspath)
+        out_tiff_file = Path(tiff_data.abspath)
+
+        # sanity check
+        assert(inp_dicom_dir.is_dir())
+
+        # WSI-DICOM to TIFF conversion (if the file doesn't exist yet)
+        if out_tiff_file.is_file():
+            print("CONVERT ERROR: File already exists: ", out_tiff_file)
+            return None
+        else:
+            # run conversion using panimg
+            dcm_input_files = {f for f in inp_dicom_dir.glob("*.dcm") if f.is_file()}
+
+            try:
+                for result in image_builder_tiff(files=dcm_input_files):
+                    tiff_image = result.file  # Path to the tiff file
+                    shutil.move(str(tiff_image), str(out_tiff_file))
+            except UnconsumedFilesException as e:
+                # e.errors is keyed with a Path to a file that could not be consumed,
+                # with a list of all the errors found with loading it,
+                # the user can then choose what to do with that information
+                print("CONVERT ERROR: UnconsumedFilesException during PanImg conversion: ", e.errors)
+                return None
+
+            return tiff_data


### PR DESCRIPTION
### PR changes:

* I have created two dataconverter classes: MhaPanImgConverter (Dicom/NRRD -> MHA), and TiffPanImgConverter (WSI-Dicom -> Tiff), for now these are placed under: `/models/xie2020_lobe_segmentation/utils/PanImgConverters.py`, but are intended to be moved to `mhubio/modules/convert`
* Created a working example by modifing the Xie lobe segmentation algorithm to use the new converters;
  *  Dockerfile: added the required panimg dependency install (will require an update of the MHubAI/models.git commit hash to work correctly, which I wasn't able to include yet!), also should probably be moved as part of the base MHub Docker images at some point after the data converter classes are migrated to mhubio.
  * config.yml: removed the NRRDConverter step, changed the source seg type for the output to MHA
  * run scripts: Added the MHAPanImgConverter to the pipeline
  * LobeSegmentationRunner: Changed the expected IO decorators to MHA

### Comments

I think that this PR should provide a good starting point for properly integrating the panimg conversion tools and for establishing a good standard template for further algorithm exchange. On my machine, I can get the example pipeline to run using the added MhaPanImgConverter, instead of using the NrrdConverter. The input and output types have been changed to MHA, since this will be the default for most of the GC algorithms. This change might break the slicer integration since the output isn't converted back to nrrd at the end of the pipeline, if this is the case we could easily add a converter for that as well. 

As a final minor concern, with my current working version, I am constantly running into the following error, at the end of the pipeline, but I think this should be easily solvable:
```
Start DsegConverter
ERROR: DsegConverter failed processing instance <I:/app/data/sorted_data/1.3.6.1.4.1.14519.5.2.1.6279.6001.179049373636438705059720603192>: __init__() got an unexpected keyword argument 'body_part_examined' in Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/mhubio/core/IO.py", line 102, in wrapper
    func(self, instance, *args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/mhubio/core/IO.py", line 129, in wrapper
    func(self, instance, *args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/mhubio/core/IO.py", line 117, in wrapper
    func(self, instance, *args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/mhubio/core/IO.py", line 165, in wrapper
    func(self, instance, *args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/mhubio/modules/convert/DsegConverter.py", line 55, in task
    generator = DcmqiDsegConfigGenerator(
TypeError: __init__() got an unexpected keyword argument 'body_part_examined'
```

This error seems to be related to a version mismatch in the DcmqiDsegConfigGenerator __init__ interface not yet expecting the `body_part_examined` argument and seems part of the latest MHub base image that I use. What would be the recommended way to solve this?

