### PR TITLE
Cleanup git in base image

### DIFF
--- a/base/buildutils/import_mhub_model.sh
+++ b/base/buildutils/import_mhub_model.sh
@@ -36,7 +36,7 @@ fi
 
 # perform a sparse checkout of the model definition folder 
 # (models/<model_name>) from the referenced repository and branch
-git stash
+git init
 git fetch ${REPO_URL} ${REPO_BRANCH}
 git merge FETCH_HEAD
 git sparse-checkout set "models/${MODEL_NAME}"

--- a/base/dockerfiles/Dockerfile
+++ b/base/dockerfiles/Dockerfile
@@ -64,7 +64,8 @@ RUN pip3 install git+https://github.com/MHubAI/mhubio.git \
   && mv base/buildutils . \
   && chmod +x base/bin/* \
   && cp base/bin/* /usr/bin/ \
-  && rm -r base
+  && rm -r base \
+  && rm -r .git
 
 # Install DCMQI by pulling the latest release from GitHub (via GitHub API)
 # Run everything in a single RUN command to avoid creating intermediate layers (and allowing environment variables to be used)


### PR DESCRIPTION
Instead of reusing the git environment from pulling our base folder, we remove the git folder and set-up a new git environment during sparse checkout of the individual model definition.