### PR TITLE
IDC - Implementing the nnUNet Task024 Whole Prostate Gland MR (T2 only) Model

### DIFF
--- a/models/nnunet_prostate_task24/config/default.yml
+++ b/models/nnunet_prostate_task24/config/default.yml
@@ -1,0 +1,41 @@
+general:
+  data_base_dir: /app/data
+  version: 1.0
+  description: default configuration for nnUNet MR Prostate segmentation (dicom to dicom)
+
+execute:
+- DicomImporter
+- NiftiConverter
+- NNUnetRunner
+- DsegConverter
+- DataOrganizer
+
+modules:
+  DicomImporter:
+    source_dir: input_data
+    import_dir: sorted_data
+    sort_data: true
+    meta: 
+      mod: 'mr'
+
+  NiftiConverter:
+    in_datas: dicom:mod=mr
+    engine: dcm2niix
+
+  NNUnetRunner:
+    in_data: nifti:mod=mr
+    nnunet_task: Task024_Promise
+    nnunet_model: 3d_fullres
+    roi: PROSTATE
+
+  BamfProcessorRunner:
+
+  DsegConverter:
+    source_segs: nifti:mod=seg
+    target_dicom: dicom:mod=mr
+    model_name: 'nnUNet MR Prostate'
+    skip_empty_slices: True
+
+  DataOrganizer:
+    targets:
+    - dicomseg-->[i:sid]/nnunet_mr_prostate.seg.dcm

--- a/models/nnunet_prostate_task24/config/default.yml
+++ b/models/nnunet_prostate_task24/config/default.yml
@@ -27,9 +27,7 @@ modules:
     nnunet_task: Task024_Promise
     nnunet_model: 3d_fullres
     roi: PROSTATE
-
-  BamfProcessorRunner:
-
+    
   DsegConverter:
     source_segs: nifti:mod=seg
     target_dicom: dicom:mod=mr

--- a/models/nnunet_prostate_task24/config/default.yml
+++ b/models/nnunet_prostate_task24/config/default.yml
@@ -16,7 +16,7 @@ modules:
     import_dir: sorted_data
     sort_data: true
     meta: 
-      mod: 'mr'
+      mod: '%Modality'
 
   NiftiConverter:
     in_datas: dicom:mod=mr

--- a/models/nnunet_prostate_task24/dockerfiles/Dockerfile
+++ b/models/nnunet_prostate_task24/dockerfiles/Dockerfile
@@ -1,0 +1,32 @@
+FROM mhubai/base:latest
+
+# FIXME: set this environment variable as a shortcut to avoid nnunet crashing the build
+# by pulling sklearn instead of scikit-learn
+# N.B. this is a known issue:
+# https://github.com/MIC-DKFZ/nnUNet/issues/1281 
+# https://github.com/MIC-DKFZ/nnUNet/pull/1209
+ENV SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True
+
+# Install nnunet and platipy
+RUN pip3 install --no-cache-dir \
+  nnunet 
+
+# Clone the main branch of MHubAI/models
+ARG MHUB_MODELS_REPO
+RUN buildutils/import_mhub_model.sh nnunet_prostate_task24 ${MHUB_MODELS_REPO}
+
+# Pull weights into the container
+ENV WEIGHTS_DIR=/root/.nnunet/nnUNet_models/nnUNet/
+RUN mkdir -p $WEIGHTS_DIR
+ENV WEIGHTS_FN=Task024_Promise.zip
+ENV WEIGHTS_URL=https://zenodo.org/records/4003545/files/$WEIGHTS_FN
+RUN wget --directory-prefix ${WEIGHTS_DIR} ${WEIGHTS_URL}
+RUN unzip ${WEIGHTS_DIR}${WEIGHTS_FN} -d ${WEIGHTS_DIR}
+RUN rm ${WEIGHTS_DIR}${WEIGHTS_FN}
+
+# specify nnunet specific environment variables
+ENV WEIGHTS_FOLDER=$WEIGHTS_DIR
+
+# Default run script
+ENTRYPOINT ["mhub.run"]
+CMD ["--config", "/app/models/nnunet_prostate_task24/config/default.yml"]

--- a/models/nnunet_prostate_task24/meta.json
+++ b/models/nnunet_prostate_task24/meta.json
@@ -1,6 +1,6 @@
 {
     "id": "...",
-    "name": "nnunet_prostate_task24_promise",
+    "name": "nnunet_prostate_task24",
     "title": "nnU-Net (Whole prostate segmentation)",
     "summary": {
         "description": "nnU-Net's whole prostate segmentation model is a single-modality (i.e. T2) input AI-based pipeline for the automated segmentation of the whole prostate on MRI scans.",
@@ -86,7 +86,23 @@
         "evaluation": {
             "title": "Evaluation Data",
             "text": "The evaluation dataset consists of 30 test samples coming from the Promise12 challenge.",
-            "tables": [],
+            "tables": [
+                {
+                "label": "Promise12 training set Average DSC using five fold cross-validation",
+                "entries": {
+                    "2D": "0.8932",
+                    "3d_fullres": "0.8891",
+                    "Best ensemble (2D + 3D_fullres)": "0.9029",
+                    "Postprocessed": "0.9030",
+                }
+            },
+                {
+                "label": "Promise12 test set Average DSC",
+                "entries": {
+                    "Test set average DSC": "0.9194m"
+                }
+            }
+            ],
             "references": [
                 {
                     "label": "Evaluation of prostate segmentation algorithms for MRI: The PROMISE12 challenge",

--- a/models/nnunet_prostate_task24/meta.json
+++ b/models/nnunet_prostate_task24/meta.json
@@ -1,0 +1,125 @@
+{
+    "id": "...",
+    "name": "nnunet_prostate_task24_promise",
+    "title": "nnU-Net (Whole prostate segmentation)",
+    "summary": {
+        "description": "nnU-Net's whole prostate segmentation model is a single-modality (i.e. T2) input AI-based pipeline for the automated segmentation of the whole prostate on MRI scans.",
+        "inputs": [
+            {
+                "label": "T2 input image",
+                "description": "The T2 axial-acquired sequence being the input image",
+                "format": "DICOM",
+                "modality": "MR",
+                "bodypartexamined": "Prostate",
+                "slicethickness": "3.6 mm",
+                "non-contrast": true,
+                "contrast": false
+            }
+        ],
+        "outputs": [
+            {
+                "type": "Segmentation",
+                "classes": [
+                    "PROSTATE"
+                ]
+            }
+        ],
+        "model": {
+            "architecture": "U-net",
+            "training": "supervised",
+            "cmpapproach": "3D"
+        },
+        "data": {
+            "training": {
+                "vol_samples": 50
+            },
+            "test": {
+                "vol_samples": 30
+            },
+            "public": true,
+            "external": false
+        }
+    },
+    "details": {
+        "name": "nnU-Net whole prostate segmentation model",
+        "version": "1.0.0",
+        "devteam": "MIC-DKFZ (Helmholtz Imaging Applied Computer Vision Lab)",
+        "type": "nnU-Net (U-Net structure, optimized by data-driven heuristics)",
+        "date": {
+            "weights": "2020",
+            "code": "2020",
+            "pub": "2020"
+        },
+        "cite": "Isensee, F., Jaeger, P. F., Kohl, S. A., Petersen, J., & Maier-Hein, K. H. (2020). nnU-Net: a self-configuring method for deep learning-based biomedical image segmentation. Nature Methods, 1-9.",
+        "license": {
+            "code": "Apache 2.0",
+            "weights": "CC BY-NC 4.0"
+        },
+        "publications": [
+            {
+                "title": "nnU-Net: a self-configuring method for deep learning-based biomedical image segmentation",
+                "uri": "https://www.nature.com/articles/s41592-020-01008-z"
+            }
+        ],
+        "github": "https://github.com/MIC-DKFZ/nnUNet/tree/nnunetv1",
+        "zenodo": "https://zenodo.org/record/4485926"
+    },
+    "info": {
+        "use": {
+            "title": "Intended Use",
+            "text": "This model is intended to perform prostate anatomy segmentation in MR T2 scans. The slice thickness of the training data is 2.2~4mm. Endorectal coil was present during training."
+        },
+        "analyses": {
+            "title": "Quantitative Analyses",
+            "text": "The model's performance was assessed using the Dice Coefficient, in the context of the Promise12 challenge. The complete breakdown of the metrics can be consulted on GrandChallenge [1] and is reported in the supplementary material to the publication [2].",
+            "references": [
+                {
+                    "label": "Evaluation of prostate segmentation algorithms for MRI: The PROMISE12 challenge",
+                    "uri": "https://doi.org/10.1016/j.media.2013.12.002"
+                },
+                {
+                    "label": "nnU-Net: a self-configuring method for deep learning-based biomedical image segmentation",
+                    "uri": "https://www.nature.com/articles/s41592-020-01008-z"
+                }
+            ]
+        },
+        "evaluation": {
+            "title": "Testing Data",
+            "text": "The test dataset consists of 30 test samples coming from the same training collection.",
+            "tables": [],
+            "references": [
+                {
+                    "label": "Evaluation of prostate segmentation algorithms for MRI: The PROMISE12 challenge",
+                    "uri": "https://doi.org/10.1016/j.media.2013.12.002"
+                },
+                {
+                    "label": "PROMISE12 dataset (direct download)",
+                    "uri": "https://zenodo.org/records/8026660"
+                }
+            ]
+        },
+        "training": {
+            "title": "Training Data",
+            "text": "The training dataset consists of 50 MRI cases containing the prostate, from the Promise12 challenge. The authors report the following characteristics for the training dataset:",
+            "tables": [
+                {
+                    "label": "Medical Image Decathlon dataset (training)",
+                    "entries": {
+                        "Slice Thickness": "2.2~4 mm",
+                        "In-Plane Resolution": "0.27 mm"
+                    }
+                }
+            ],
+            "references": [
+                {
+                    "label": "Evaluation of prostate segmentation algorithms for MRI: The PROMISE12 challenge",
+                    "uri": "https://doi.org/10.1016/j.media.2013.12.002"
+                },
+                {
+                    "label": "PROMISE12 dataset (direct download)",
+                    "uri": "https://zenodo.org/records/8026660"
+                }
+            ]
+        }
+    }
+}

--- a/models/nnunet_prostate_task24/meta.json
+++ b/models/nnunet_prostate_task24/meta.json
@@ -33,7 +33,7 @@
             "training": {
                 "vol_samples": 50
             },
-            "test": {
+            "evaluation": {
                 "vol_samples": 30
             },
             "public": true,
@@ -84,8 +84,8 @@
             ]
         },
         "evaluation": {
-            "title": "Testing Data",
-            "text": "The test dataset consists of 30 test samples coming from the same training collection.",
+            "title": "Evaluation Data",
+            "text": "The evaluation dataset consists of 30 test samples coming from the Promise12 challenge.",
             "tables": [],
             "references": [
                 {

--- a/models/nnunet_prostate_task24/meta.json
+++ b/models/nnunet_prostate_task24/meta.json
@@ -71,7 +71,7 @@
         },
         "analyses": {
             "title": "Quantitative Analyses",
-            "text": "The model's performance was assessed using the Dice Coefficient, in the context of the Promise12 challenge. The complete breakdown of the metrics can be consulted on GrandChallenge [1] and is reported in the supplementary material to the publication [2].",
+            "text": "The model's performance was assessed using the Dice Coefficient, in the context of the Promise12 challenge. A brief summary of the evaluation results on internal data can be found in the evaluation section. The complete breakdown of the metrics can be consulted on GrandChallenge [1] and is reported in the supplementary material to the publication [2].",
             "references": [
                 {
                     "label": "Evaluation of prostate segmentation algorithms for MRI: The PROMISE12 challenge",
@@ -88,20 +88,20 @@
             "text": "The evaluation dataset consists of 30 test samples coming from the Promise12 challenge.",
             "tables": [
                 {
-                "label": "Promise12 training set Average DSC using five fold cross-validation",
-                "entries": {
-                    "2D": "0.8932",
-                    "3d_fullres": "0.8891",
-                    "Best ensemble (2D + 3D_fullres)": "0.9029",
-                    "Postprocessed": "0.9030",
-                }
-            },
+                    "label": "Promise12 training set Average DSC using five fold cross-validation",
+                    "entries": {
+                        "2D": "0.8932",
+                        "3d_fullres": "0.8891",
+                        "Best ensemble (2D + 3D_fullres)": "0.9029",
+                        "Postprocessed": "0.9030"
+                    }
+                },
                 {
-                "label": "Promise12 test set Average DSC",
-                "entries": {
-                    "Test set average DSC": "0.9194m"
+                    "label": "Promise12 test set Average DSC",
+                    "entries": {
+                        "Test set average DSC": "0.9194"
+                    }
                 }
-            }
             ],
             "references": [
                 {


### PR DESCRIPTION
This is my implementation of the nnUNet Whole Prostate MR (Task024) model, trained on Promise12 challenge data.

The model is single-modality, namely T2, and segments the whole prostate gland.

Building and testing of the model dockerfile is next.