### PR TITLE
Update Dockerfile Entrypoint in all models

### DIFF
--- a/.github/scripts/utils.py
+++ b/.github/scripts/utils.py
@@ -214,8 +214,8 @@ def validateDockerfile(base: str, model_name: str):
                 raise MHubComplianceError(f"Collection '{collection['name']}' is not imported by its name.", DocuRef.DOCKERFILE)
 
     # check that the entrypoint of the dockerfile matches
-    #  ENTRYPOINT ["mhub.run"]  |  ENTRYPOINT ["python", "-m", "mhubio.run"]
-    if not lines[-2].strip() in ['ENTRYPOINT ["mhub.run"]', 'ENTRYPOINT ["python3", "-m", "mhubio.run"]']:
+    #  ENTRYPOINT ["mhub.run"]  |  ENTRYPOINT ["python", "-m", "mhubio.run"] (deprecated, no longer allowed)
+    if not lines[-2].strip() == 'ENTRYPOINT ["mhub.run"]':
         raise MHubComplianceError(f"Dockerfile does not contain the correct entrypoint: {lines[-2]}", DocuRef.DOCKERFILE)
     
     #  CMD ["--workflow", "default"] | CMD ["--config", "/app/models/$model_name/config/default.yml"]

--- a/models/casust/dockerfiles/Dockerfile
+++ b/models/casust/dockerfiles/Dockerfile
@@ -43,5 +43,5 @@ ARG MHUB_MODELS_REPO
 RUN buildutils/import_mhub_model.sh casust ${MHUB_MODELS_REPO}
 
 # Default run script
-ENTRYPOINT ["python3", "-m", "mhubio.run"]
+ENTRYPOINT ["mhub.run"]
 CMD ["--config", "/app/models/casust/config/default.yml"]

--- a/models/gc_autopet_fpr/dockerfiles/Dockerfile
+++ b/models/gc_autopet_fpr/dockerfiles/Dockerfile
@@ -42,5 +42,5 @@ RUN buildutils/import_mhub_model.sh gc_autopet_fpr ${MHUB_MODELS_REPO}
 ENV PYTHONPATH "/app:/opt/algorithm"
 
 # Configure main entrypoint
-ENTRYPOINT ["python3", "-m", "mhubio.run"]
+ENTRYPOINT ["mhub.run"]
 CMD ["--config", "/app/models/gc_autopet_fpr/config/default.yml"]

--- a/models/gc_grt123_lung_cancer/dockerfiles/Dockerfile
+++ b/models/gc_grt123_lung_cancer/dockerfiles/Dockerfile
@@ -31,5 +31,5 @@ RUN buildutils/import_mhub_model.sh gc_grt123_lung_cancer ${MHUB_MODELS_REPO}
 ENV PYTHONPATH="/gc_grt123_lung_cancer:/app"
 
 # Default entrypoint
-ENTRYPOINT ["python3", "-m", "mhubio.run"]
+ENTRYPOINT ["mhub.run"]
 CMD ["--config", "/app/models/gc_grt123_lung_cancer/config/default.yml"]

--- a/models/gc_lunglobes/dockerfiles/Dockerfile
+++ b/models/gc_lunglobes/dockerfiles/Dockerfile
@@ -24,5 +24,5 @@ RUN git clone --depth 1 --branch v1.6.5 https://github.com/DIAGNijmegen/bodyct-p
     sed -i 's/from models import CTSUNet/from src.models import CTSUNet/g' src/test.py
 
 # Default run script
-ENTRYPOINT ["python3", "-m", "mhubio.run"]
+ENTRYPOINT ["mhub.run"]
 CMD ["--config", "/app/models/gc_lunglobes/config/default.yml"]

--- a/models/gc_nnunet_pancreas/dockerfiles/Dockerfile
+++ b/models/gc_nnunet_pancreas/dockerfiles/Dockerfile
@@ -41,5 +41,5 @@ RUN buildutils/import_mhub_model.sh gc_nnunet_pancreas ${MHUB_MODELS_REPO}
 ENV PYTHONPATH=/opt/algorithm:/app
 
 # Configure main entrypoint
-ENTRYPOINT ["python3", "-m", "mhubio.run"]
+ENTRYPOINT ["mhub.run"]
 CMD ["--config", "/app/models/gc_nnunet_pancreas/config/default.yml"]

--- a/models/gc_node21_baseline/dockerfiles/Dockerfile
+++ b/models/gc_node21_baseline/dockerfiles/Dockerfile
@@ -37,5 +37,5 @@ ENV TORCH_HOME /opt/algorithm
 ENV PYTHONPATH "/app:/opt/algorithm"
 
 # Specify default entrypoint
-ENTRYPOINT ["python3", "-m", "mhubio.run"]
+ENTRYPOINT ["mhub.run"]
 CMD ["--config", "/app/models/gc_node21_baseline/config/default.yml"]

--- a/models/gc_picai_baseline/dockerfiles/Dockerfile
+++ b/models/gc_picai_baseline/dockerfiles/Dockerfile
@@ -51,5 +51,5 @@ RUN buildutils/import_mhub_model.sh gc_picai_baseline ${MHUB_MODELS_REPO}
 ENV PYTHONPATH="/app:/opt/algorithm"
 
 # Default entrypoint
-ENTRYPOINT ["python3", "-m", "mhubio.run"]
+ENTRYPOINT ["mhub.run"]
 CMD ["--config", "/app/models/gc_picai_baseline/config/default.yml"]

--- a/models/gc_spider_baseline/dockerfiles/Dockerfile
+++ b/models/gc_spider_baseline/dockerfiles/Dockerfile
@@ -35,5 +35,5 @@ ENV PYTHONPATH="/app:/app/src/devel"
 ENV VERSEG_BASEDIR="/app/src/"
 
 # Default run script
-ENTRYPOINT ["python3", "-m", "mhubio.run"]
+ENTRYPOINT ["mhub.run"]
 CMD ["--config", "/app/models/gc_spider_baseline/config/default.yml"]

--- a/models/gc_stoic_baseline/dockerfiles/Dockerfile
+++ b/models/gc_stoic_baseline/dockerfiles/Dockerfile
@@ -31,5 +31,5 @@ ENV STOIC_SRC_PATH=/app/src
 ENV PYTHONPATH=/app:${STOIC_SRC_PATH}
 
 # Default run script
-ENTRYPOINT ["python3", "-m", "mhubio.run"]
+ENTRYPOINT ["mhub.run"]
 CMD ["--config", "/app/models/gc_stoic_baseline/config/default.yml"]

--- a/models/gc_tiger_lb2/dockerfiles/Dockerfile
+++ b/models/gc_tiger_lb2/dockerfiles/Dockerfile
@@ -51,5 +51,5 @@ RUN buildutils/import_mhub_model.sh gc_tiger_lb2 ${MHUB_MODELS_REPO}
 ENV PYTHONPATH="/vuno:/app"
 
 # Set default entrypoint
-ENTRYPOINT ["python3", "-m", "mhubio.run"]
+ENTRYPOINT ["mhub.run"]
 CMD ["--config", "/app/models/gc_tiger_lb2/config/default.yml"]

--- a/models/gc_wsi_bgseg/dockerfiles/Dockerfile
+++ b/models/gc_wsi_bgseg/dockerfiles/Dockerfile
@@ -60,5 +60,5 @@ RUN git clone --depth 1 --branch 1.0.0 https://github.com/DIAGNijmegen/pathology
 ENV PYTHONPATH="/app:/app/src"
 
 # Default run script
-ENTRYPOINT ["python3", "-m", "mhubio.run"]
+ENTRYPOINT ["mhub.run"]
 CMD ["--config", "/app/models/gc_wsi_bgseg/config/default.yml"]

--- a/models/lungmask/dockerfiles/Dockerfile
+++ b/models/lungmask/dockerfiles/Dockerfile
@@ -20,5 +20,5 @@ ENV WEIGHTS_URL="https://github.com/JoHof/lungmask/releases/download/v0.0/unet_l
 RUN wget --directory-prefix ${WEIGHTS_DIR} ${WEIGHTS_URL}
 
 # Default run script
-ENTRYPOINT ["python3", "-m", "mhubio.run"]
+ENTRYPOINT ["mhub.run"]
 CMD ["--config", "/app/models/lungmask/config/default.yml"]

--- a/models/nnunet_liver/dockerfiles/Dockerfile
+++ b/models/nnunet_liver/dockerfiles/Dockerfile
@@ -28,5 +28,5 @@ RUN rm ${WEIGHTS_DIR}${WEIGHTS_FN}
 ENV WEIGHTS_FOLDER=$WEIGHTS_DIR
 
 # Default run script
-ENTRYPOINT ["python3", "-m", "mhubio.run"]
+ENTRYPOINT ["mhub.run"]
 CMD ["--config", "/app/models/nnunet_liver/config/default.yml"]

--- a/models/nnunet_pancreas/dockerfiles/Dockerfile
+++ b/models/nnunet_pancreas/dockerfiles/Dockerfile
@@ -28,5 +28,5 @@ RUN rm ${WEIGHTS_DIR}${WEIGHTS_FN}
 ENV WEIGHTS_FOLDER=$WEIGHTS_DIR
 
 # Default run script
-ENTRYPOINT ["python3", "-m", "mhubio.run"]
+ENTRYPOINT ["mhub.run"]
 CMD ["--config", "/app/models/nnunet_pancreas/config/default.yml"]

--- a/models/platipy/dockerfiles/Dockerfile
+++ b/models/platipy/dockerfiles/Dockerfile
@@ -39,5 +39,5 @@ RUN unzip ${WEIGHTS_DIR}${WEIGHTS_FN} -d ${WEIGHTS_DIR}
 RUN rm ${WEIGHTS_DIR}${WEIGHTS_FN}
 
 # Default run script
-ENTRYPOINT ["python3", "-m", "mhubio.run"]
+ENTRYPOINT ["mhub.run"]
 CMD ["--config", "/app/models/platipy/config/default.yml"]

--- a/models/pyradiomics/dockerfiles/Dockerfile
+++ b/models/pyradiomics/dockerfiles/Dockerfile
@@ -9,5 +9,5 @@ ARG MHUB_MODELS_REPO
 RUN buildutils/import_mhub_model.sh pyradiomics ${MHUB_MODELS_REPO}
 
 # Default run script
-ENTRYPOINT ["python3", "-m", "mhubio.run"]
+ENTRYPOINT ["mhub.run"]
 CMD ["--config", "/app/models/pyradiomics/config/default.yml"]

--- a/models/totalsegmentator/dockerfiles/Dockerfile
+++ b/models/totalsegmentator/dockerfiles/Dockerfile
@@ -26,5 +26,5 @@ RUN buildutils/download_weights.sh \
   https://zenodo.org/record/6802452/files/Task255_TotalSegmentator_part5_ribs_1139subj.zip
 
 # Default run script
-ENTRYPOINT ["python3", "-m", "mhubio.run"]
+ENTRYPOINT ["mhub.run"]
 CMD ["--config", "/app/models/totalsegmentator/config/default.yml"]


### PR DESCRIPTION
- update our compliance rule to only allow `ENTRYPOINT ["mhub.run"]`
- replace `ENTRYPOINT ["python3", "-m", "mhubio.run"]` in all models using the old, legacy entrypoint.

By standardizing the entry point into our mhub.run script, we have a central control point for how the run script is started.
This will make it easier to migrate to an updated Python version and use a venv in the future.