### PR TITLE
Upgrade MHub to uv and python3.11

### DIFF
--- a/base/bin/mhub.run
+++ b/base/bin/mhub.run
@@ -1,3 +1,4 @@
 #!/bin/bash
-PYTHON=$(which python3)
-$PYTHON -m mhubio.run "$@"
+# PYTHON=$(uv run which python3)
+# $PYTHON -m mhubio.run "$@"
+uv run python -m mhubio.run "$@"

--- a/base/bin/mhub.update
+++ b/base/bin/mhub.update
@@ -1,4 +1,3 @@
 #!/bin/bash
-PYTHON=$(which python3)
-$PYTHON -m pip uninstall -y mhubio segdb
-$PYTHON -m pip install git+https://github.com/MHubAI/mhubio.git git+https://github.com/MHubAI/segdb.git
+uv pip uninstall mhubio segdb
+uv pip install git+https://github.com/MHubAI/mhubio.git git+https://github.com/MHubAI/segdb.git

--- a/base/bin/mhub.version
+++ b/base/bin/mhub.version
@@ -3,10 +3,10 @@
 MODEL_FOLDER="/app/models/"
 
 # mhubio version
-MHUBIO=$(pip freeze | grep mhubio | cut -d"@" -f3)
+MHUBIO=$(uv pip freeze | grep mhubio | cut -d"@" -f3)
 
 # segdb version
-SEGDB=$(pip freeze | grep segdb | cut -d"@" -f3)
+SEGDB=$(uv pip freeze | grep segdb | cut -d"@" -f3)
 
 echo -e "mhubio==${MHUBIO}"
 echo -e "segdb==${SEGDB}"
@@ -37,21 +37,21 @@ fi
 # pip freeze without segdb and mhubio (already on top of the lists,
 # since for now they are commits). Ideally, this should return only pip versions
 # (although some package might be installed from git by contributors)
-pip freeze | grep -v "segdb" | grep -v "mhubio"
+uv pip freeze | grep -v "segdb" | grep -v "mhubio"
 
 # collect additional information on installed system dependencies.
 #  to allow contributors to include additional dependencies, we should use a environment variable or a file instead.
 
 # versions of python, pip, plastimatch, jq, git, libopenslide-dev, libvips-dev, dcm2niix, ffmpeg, libsm6, libxext6
 # echo -e "+++"
-# echo -e "python==$(python3 --version 2>&1)"
+# echo -e "python==$(python3 --version 2>&1 | cut -d" " -f2)"
 # echo -e "pip==$(pip --version 2>&1)"
-# echo -e "plastimatch==$(plastimatch --version 2>&1)"
+# echo -e "plastimatch==$(plastimatch --version 2>&1 | cut -d" " -f3)"
 # echo -e "jq==$(jq --version 2>&1)"
-# echo -e "git==$(git --version 2>&1)"
-# echo -e "libopenslide-dev==$(dpkg -s libopenslide-dev | grep Version)"
-# echo -e "libvips-dev==$(dpkg -s libvips-dev | grep Version)"
+# echo -e "git==$(git --version 2>&1 | cut -d" " -f3)"
+# echo -e "libopenslide-dev==$(dpkg -s libopenslide-dev | grep Version | cut -d" " -f2)"
+# echo -e "libvips-dev==$(dpkg -s libvips-dev | grep Version | cut -d" " -f2)"
 # echo -e "dcm2niix==$(dcm2niix -h | grep "dcm2niiX version" | cut -d"v" -f3)"
 # echo -e "ffmpeg==$(ffmpeg -version 2>&1 | grep ffmpeg | cut -d" " -f3)"
-# echo -e "libsm6==$(dpkg -s libsm6 | grep Version)"
-# echo -e "libxext6==$(dpkg -s libxext6 | grep Version)"
+# echo -e "libsm6==$(dpkg -s libsm6 | grep Version | cut -d" " -f2)"
+# echo -e "libxext6==$(dpkg -s libxext6 | grep Version | cut -d" " -f2)"

--- a/base/dockerfiles/Dockerfile
+++ b/base/dockerfiles/Dockerfile
@@ -13,7 +13,8 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # Create a working directory and set it as the working directory
 # Also create directories for input and output data (mounting points) in the same RUN to avoid creating intermediate layers
-RUN mkdir -p /app /app/data /app/data/input_data /app/data/output_data /app/utility/config /app/xmodules /app/xcollections
+RUN mkdir -p /app/data /app/data/input_data /app/data/output_data /app/data/reference_data \
+             /app/utility/config /app/xmodules /app/xcollections
 WORKDIR /app
 
 # Install system utilities and useful packages
@@ -25,8 +26,8 @@ RUN apt update && apt install -y --no-install-recommends \
   unzip \
   sudo \
   git \
-  python3 \
-  python3-pip
+  tree \
+  clang
 
 # Install core MHubIO modules requirements (python3-openslide and libvips-dev are dependencies of panimg)
 RUN apt update && apt install -y --no-install-recommends \
@@ -34,33 +35,54 @@ RUN apt update && apt install -y --no-install-recommends \
   libvips-dev \
   plastimatch \
   ffmpeg libsm6 libxext6 \
+  ca-certificates \
   && rm -rf /var/lib/apt/lists/* 
 
-# Install general python utilities (specify version if necessary)
-RUN pip3 install --upgrade pip && pip3 install --no-cache-dir \
-  typing-extensions \
-  Pillow==9.5.0 \
-  h5py \
-  numpy \
-  pandas \ 
-  panimg \
-  pydicom \
-  pydicom-seg \
-  highdicom \
-  rt_utils \
-  PyYAML \
-  pyplastimatch \
-  SimpleITK==2.2.1 \
-  thedicomsort \
-  colorspacious \
-  jsonschema==4.21.1 \
-  dcmqi==0.2.0 \
-  dcm2niix==1.0.20220715
+# Install uv (download installer, run & remove installer, add to PATH)
+ADD https://astral.sh/uv/0.4.4/install.sh /uv-installer.sh
+RUN sh /uv-installer.sh && rm /uv-installer.sh
+ENV PATH="/root/.cargo/bin/:$PATH"
 
-# Install mhubio framework from git, pulls the utils scripts from GitHub
-RUN pip3 install git+https://github.com/MHubAI/mhubio.git \
-  && pip3 install git+https://github.com/MHubAI/segdb.git \
-  && git init \
+# install python3.11 via uv into .venv
+RUN uv venv -p 3.11
+
+# Add a link to pip3 for compatibility
+# NOTE: model implementations should install dependencies into separate virtual environments and use a cli script.
+# RUN uv pip install --no-cache pip && mkdir /mhub-compatibility && ln -s $(uv run which pip) /mhub-compatibility/pip3
+# ENV PATH="/mhub-compatibility:$PATH"
+RUN uv pip install --no-cache pip \
+ && ln -s $(uv run which pip) /usr/bin/pip3
+
+# Install general python utilities (specify version if necessary)
+# NOTE: these dependencies will be declared as part of mhubio in an upcoming release.
+# RUN uv pip install --no-cache typing-extensions Pillow h5py numpy pandas panimg pydicom pydicom-seg highdicom rt_utils PyYAML pyplastimatch SimpleITK thedicomsort colorspacious jsonschema dcmqi dcm2niix toml
+RUN uv pip install --no-cache \
+  "colorspacious~=1.1.2" \
+  "dcm2niix~=1.0.20220715" \
+  "dcmqi~=0.2.0" \
+  "h5py~=3.11.0" \
+  "highdicom~=0.22.0" \
+  "jsonschema~=3.2.0" \
+  "pandas~=2.2.2" \
+  "panimg~=0.13.2" \
+  "pillow~=10.4.0" \
+  "pydicom-seg~=0.4.1" \
+  "pydicom~=2.4.4" \
+  "pyplastimatch~=0.4.6" \
+  "pyyaml~=6.0.2" \
+  "rt-utils~=1.2.7" \
+  "simpleitk~=2.4.0" \
+  "thedicomsort~=1.0.1" \
+  "toml~=0.10.2" \
+  "typing-extensions~=4.12.2"
+
+# Install mhub dependencies and tools
+RUN uv pip install git+https://github.com/MHubAI/mhubio.git \
+  && uv pip install git+https://github.com/MHubAI/segdb.git  \
+  && uv tool install git+https://github.com/LennyN95/medcmp.git@pyproject_restructure_poetry
+
+# Install the base image utilities
+RUN git init \
   && git sparse-checkout set "base/buildutils" "base/bin" "base/configs" "base/collections.json" \
   && git fetch https://github.com/MHubAI/models.git main \
   && git merge FETCH_HEAD \
@@ -75,6 +97,10 @@ RUN pip3 install git+https://github.com/MHubAI/mhubio.git \
 
 # Set PYTHONPATH to the /app folder
 ENV PYTHONPATH="/app"
+
+# FIXME: DEV ONY
+COPY base/bin/* /usr/bin/
+RUN chmod +x /usr/bin/*
 
 # FIXME: pass it as a command to the container in Slicer
 CMD ["echo", "MHub Ubuntu 20.04 base image. Visit http://mhub.ai to find out more!"]

--- a/base/dockerfiles/Dockerfile
+++ b/base/dockerfiles/Dockerfile
@@ -98,9 +98,6 @@ RUN git init \
 # Set PYTHONPATH to the /app folder
 ENV PYTHONPATH="/app"
 
-# FIXME: DEV ONY
-COPY base/bin/* /usr/bin/
-RUN chmod +x /usr/bin/*
-
-# FIXME: pass it as a command to the container in Slicer
-CMD ["echo", "MHub Ubuntu 20.04 base image. Visit http://mhub.ai to find out more!"]
+#CMD ["echo", "MHub Ubuntu 20.04 base image. Visit http://mhub.ai to find out more!"]
+ENTRYPOINT [ "mhub.run" ]
+CMD ["--utility"]

--- a/models/gc_lunglobes/dockerfiles/Dockerfile
+++ b/models/gc_lunglobes/dockerfiles/Dockerfile
@@ -6,14 +6,21 @@ LABEL authors="sil.vandeleemput@radboudumc.nl,dbontempi@bwh.harvard.edu,lnuernbe
 # Install system dependencies for OpenCV
 RUN apt-get update && apt-get install ffmpeg libsm6 libxext6 -y
 
-# Install required dependencies for lobe segmentation (CUDA-enabled)
-RUN pip3 install --no-cache-dir \
-    opencv-python \
-    torch==2.0.1 torchvision==0.15.2 \
-    dgl==1.1.2 -f https://data.dgl.ai/wheels/cu118/repo.html
+# create new virtual environment
+RUN uv venv --python-preference only-managed -p 3.8 .venv38
 
-# SimpleITK downgrade required for legacy Resample::Execute operation
-RUN pip3 install --no-cache-dir --force-reinstall SimpleITK==1.2.4 
+# Install required dependencies for lobe segmentation (CUDA-enabled)
+#  SimpleITK==1.2.4 is required for legacy Resample::Execute operation
+RUN uv pip install -n -p .venv38 \
+    pydicom==2.4.4 packaging==24.1 psutil==6.0.0 \
+    opencv-python==4.10.0.84 \
+    torch==2.0.1 torchvision==0.15.2 \
+    SimpleITK==1.2.4                        
+
+# Install dgl (CUDA-enabled)
+# NOTE: uv pip install -f option doesn't work as intended
+RUN uv pip install -n -p .venv38 pip \
+ && uv run -p .venv38 pip install dgl==1.1.2 -f https://data.dgl.ai/wheels/cu118/repo.html
 
 # Import the MHub model definiton
 ARG MHUB_MODELS_REPO

--- a/models/gc_lunglobes/utils/run38.py
+++ b/models/gc_lunglobes/utils/run38.py
@@ -1,0 +1,43 @@
+import os
+import numpy as np 
+import SimpleITK as sitk
+
+from src.test import segment_lobe, segment_lobe_init
+
+def run(input_image_path: str, output_image_path: str):
+  
+  img_itk = sitk.ReadImage(input_image_path)
+  img_np = sitk.GetArrayFromImage(img_itk)
+
+  # apply lobe segmentation
+  origin = img_itk.GetOrigin()[::-1]
+  spacing = img_itk.GetSpacing()[::-1]
+  direction = np.asarray(img_itk.GetDirection()).reshape(3, 3)[::-1].flatten().tolist()
+  meta_dict =  {
+      "uid": os.path.basename(input_image_path),
+      "size": img_np.shape,
+      "spacing": spacing,
+      "origin": origin,
+      "original_spacing": spacing,
+      "original_size": img_np.shape,
+      "direction": direction
+  }
+
+  handle = segment_lobe_init()
+  seg_result_np = segment_lobe(handle, img_np, meta_dict)
+
+  # store image
+  print(f"Writing image to {output_image_path}")
+  seg_itk = sitk.GetImageFromArray(seg_result_np)
+  seg_itk.CopyInformation(img_itk)
+  sitk.WriteImage(seg_itk, output_image_path)
+  
+# cli
+if __name__ == "__main__":
+  import argparse
+  parser = argparse.ArgumentParser(description='Run Xie2020 Lobe Segmentation')
+  parser.add_argument('input_image_path', type=str, help='Path to input image')
+  parser.add_argument('output_image_path', type=str, help='Path to output image')
+  args = parser.parse_args()
+  
+  run(args.input_image_path, args.output_image_path)

--- a/models/gc_tiger_lb2/dockerfiles/Dockerfile
+++ b/models/gc_tiger_lb2/dockerfiles/Dockerfile
@@ -45,9 +45,6 @@ RUN buildutils/import_mhub_model.sh gc_tiger_lb2 ${MHUB_MODELS_REPO}
 # Add model and algorithm code bases to python path
 ENV PYTHONPATH="/vuno:/app"
 
-# DEV
-COPY models/gc_tiger_lb2/utils /app/models/gc_tiger_lb2/utils
-
 # Set default entrypoint
 ENTRYPOINT ["mhub.run"]
 CMD ["--config", "/app/models/gc_tiger_lb2/config/default.yml"]

--- a/models/gc_tiger_lb2/dockerfiles/Dockerfile
+++ b/models/gc_tiger_lb2/dockerfiles/Dockerfile
@@ -3,12 +3,6 @@ FROM mhubai/base:latest
 # Specify/override authors label
 LABEL authors="sil.vandeleemput@radboudumc.nl"
 
-# Install pipenv (for a custom Python/Pip environment for ASAP-2.1 and the other algorithm requirements)
-RUN pip3 install --no-cache-dir pipenv
-
-# Set environment variables for pipenv (installs into /app/.venv)
-ENV PIPENV_VENV_IN_PROJECT=1
-
 # Install ASAP 2.1
 RUN apt-get update && \
     apt-get -y install curl libpython3.8-dev && \
@@ -26,16 +20,17 @@ RUN git clone --depth 1 --branch 0.1.0 https://github.com/DIAGNijmegen/tiger_vun
     rm -rf /vuno/.git
 
 # Setup and install algorithm pipenv environment
-#   1. Ensure we configure a new empty pipenv for Python 3.8
+#   1. Ensure we configure a new empty virtual environment for Python 3.8
 #   2. Link ASAP libraries into our environment
 #   3. Install required torch and torchvision dependencies
 #   4. Install tiger LB2 dependencies from requirements.txt
 #   5. Upgrade version of numpy and numba to function correctly with ASAP
-RUN pipenv install --python 3.8 && \
-    echo "/opt/ASAP/bin" > /app/.venv/lib/python3.8/site-packages/asap.pth && \
-    pipenv run pip install --no-cache-dir torch==2.0.1+cu118 torchvision==0.15.2+cu118 -f https://download.pytorch.org/whl/torch_stable.html && \
-    pipenv run pip install --no-cache-dir -r /vuno/requirements.txt && \
-    pipenv run pip install --no-cache-dir --upgrade numpy==1.24.4 numba==0.58.1
+RUN uv venv --python 3.8 .venv38 \
+ && echo "/opt/ASAP/bin" > /app/.venv38/lib/python3.8/site-packages/asap.pth \
+ && uv pip install -n -p .venv38 -f https://download.pytorch.org/whl/torch_stable.html \
+    torch==2.0.1+cu118 torchvision==0.15.2+cu118 \
+ && uv pip install -n -p .venv38 -r /vuno/requirements.txt \
+ && uv pip install -n -p .venv38 --upgrade numpy==1.24.4 numba==0.58.1
 
 # Download and install model weights file from zenodo
 RUN rm -rf /vuno/pretrained_weights && \
@@ -49,6 +44,9 @@ RUN buildutils/import_mhub_model.sh gc_tiger_lb2 ${MHUB_MODELS_REPO}
 
 # Add model and algorithm code bases to python path
 ENV PYTHONPATH="/vuno:/app"
+
+# DEV
+COPY models/gc_tiger_lb2/utils /app/models/gc_tiger_lb2/utils
 
 # Set default entrypoint
 ENTRYPOINT ["mhub.run"]

--- a/models/gc_tiger_lb2/utils/TigerLB2Runner.py
+++ b/models/gc_tiger_lb2/utils/TigerLB2Runner.py
@@ -36,8 +36,7 @@ class TigerLB2Runner(Module):
         # Execute the Tiger LB2 Algorithm through a Python subprocess and associated pipenv environment
         self.subprocess(
             [
-                "pipenv",
-                "run",
+                "uv", "run", "-p", ".venv38",
                 "python",
                 str(self.CLI_SCRIPT_PATH),
                 in_data.abspath,

--- a/models/gc_wsi_bgseg/dockerfiles/Dockerfile
+++ b/models/gc_wsi_bgseg/dockerfiles/Dockerfile
@@ -3,15 +3,9 @@ FROM mhubai/base:latest
 # Update authors label
 LABEL authors="sil.vandeleemput@radboudumc.nl"
 
-# Install pipenv (for a custom Python/Pip environment for ASAP-2.1 and the other algorithm requirements)
-RUN pip3 install --no-cache-dir pipenv
-
-# Set environment variables for pipenv (installs into /app/.venv)
-ENV PIPENV_VENV_IN_PROJECT=1
-
 # Install ASAP 2.1
 RUN apt-get update && \
-    apt-get -y install curl libpython3.8-dev && \
+    apt-get -y install libpython3.8-dev && \
     curl --remote-name --location "https://github.com/computationalpathologygroup/ASAP/releases/download/ASAP-2.1/ASAP-2.1-py38-Ubuntu2004.deb" && \
     dpkg --install ASAP-2.1-py38-Ubuntu2004.deb || true && \
     apt-get -f install --fix-missing --fix-broken --assume-yes && \
@@ -25,15 +19,15 @@ RUN apt-get update && \
 #   3. Upgrade pip
 #   4. Upgrade version of numpy and numba to function correctly with ASAP
 #   5. Install required dependencies for algorithm
-RUN pipenv install --python 3.8 && \
-    echo "/opt/ASAP/bin" > /app/.venv/lib/python3.8/site-packages/asap.pth && \
-    pipenv run pip install --no-cache-dir --upgrade pip && \
-    pipenv run pip install --no-cache-dir --upgrade numpy==1.24.4 numba==0.58.1 && \
-    pipenv run pip install --no-cache-dir scipy==1.10.1 scikit-image==0.21.0 h5py==3.11.0
+RUN uv venv --python 3.8 .venv38 && \
+    echo "/opt/ASAP/bin" > /app/.venv38/lib/python3.8/site-packages/asap.pth && \
+    uv pip install -n -p .venv38 --upgrade numpy==1.24.4 numba==0.58.1 && \
+    uv pip install -n -p .venv38 scipy==1.10.1 scikit-image==0.21.0 h5py==3.11.0
 
 # build/install Tensorflow 2.11.0 with GPU support (without conda), with CUDA 11 toolkit and cudnn 8
 # tensorflow-2.11.0 Python 3.7-3.10 cuDNN >= 8.1 CUDA >= 11.2
-RUN pipenv run pip install --no-cache-dir \
+RUN uv pip install -n -p .venv38 pip \
+ && uv run -p .venv38 pip install --no-cache-dir \
     nvidia-cuda-runtime-cu11 \
     nvidia-cusolver-cu11 \
     nvidia-curand-cu11 \
@@ -46,8 +40,8 @@ RUN pipenv run pip install --no-cache-dir \
     --extra-index-url https://pypi.ngc.nvidia.com
 
 # Configure required paths for tensorflow with GPU support
-ENV NVIDIA_DIR /app/.venv/lib/python3.8/site-packages/nvidia
-ENV LD_LIBRARY_PATH /app/.venv/lib/python3.8/site-packages/tensorrt:$NVIDIA_DIR/cublas/lib:$NVIDIA_DIR/cuda_runtime/lib:$NVIDIA_DIR/cudnn/lib:$NVIDIA_DIR/cufft/lib:$NVIDIA_DIR/curand/lib:$NVIDIA_DIR/cusolver/lib:$NVIDIA_DIR/cusparse/lib
+ENV NVIDIA_DIR /app/.venv38/lib/python3.8/site-packages/nvidia
+ENV LD_LIBRARY_PATH /app/.venv38/lib/python3.8/site-packages/tensorrt:$NVIDIA_DIR/cublas/lib:$NVIDIA_DIR/cuda_runtime/lib:$NVIDIA_DIR/cudnn/lib:$NVIDIA_DIR/cufft/lib:$NVIDIA_DIR/curand/lib:$NVIDIA_DIR/cusolver/lib:$NVIDIA_DIR/cusparse/lib
 
 # Import the MHub model definiton
 ARG MHUB_MODELS_REPO
@@ -58,6 +52,9 @@ RUN git clone --depth 1 --branch 1.0.0 https://github.com/DIAGNijmegen/pathology
 
 # Add model and algorithm code bases to python path
 ENV PYTHONPATH="/app:/app/src"
+
+# DEV
+COPY models/gc_wsi_bgseg/utils /app/models/gc_wsi_bgseg/utils
 
 # Default run script
 ENTRYPOINT ["mhub.run"]

--- a/models/gc_wsi_bgseg/dockerfiles/Dockerfile
+++ b/models/gc_wsi_bgseg/dockerfiles/Dockerfile
@@ -53,9 +53,6 @@ RUN git clone --depth 1 --branch 1.0.0 https://github.com/DIAGNijmegen/pathology
 # Add model and algorithm code bases to python path
 ENV PYTHONPATH="/app:/app/src"
 
-# DEV
-COPY models/gc_wsi_bgseg/utils /app/models/gc_wsi_bgseg/utils
-
 # Default run script
 ENTRYPOINT ["mhub.run"]
 CMD ["--config", "/app/models/gc_wsi_bgseg/config/default.yml"]

--- a/models/gc_wsi_bgseg/utils/WSIBackgroundSegmentationRunner.py
+++ b/models/gc_wsi_bgseg/utils/WSIBackgroundSegmentationRunner.py
@@ -52,8 +52,9 @@ class WSIBackgroundSegmentationRunner(Module):
             # Execute the Tiger LB2 Algorithm through a Python subprocess and associated pipenv environment
             self.subprocess(
                 [
-                    "pipenv",
+                    "uv",
                     "run",
+                    "-p", ".venv38",
                     "python",
                     str(self.CLI_SCRIPT_PATH),
                     in_data.abspath,

--- a/models/monai_prostate158/dockerfiles/Dockerfile
+++ b/models/monai_prostate158/dockerfiles/Dockerfile
@@ -11,7 +11,7 @@ ARG MONAI_BUNDLE_DIR='https://github.com/Project-MONAI/model-zoo/releases/downlo
 ARG MONAI_MODEL_NAME='prostate_mri_anatomy'
 
 # Install nnunet and platipy
-RUN python3 -m pip install --upgrade pip && pip3 install --no-cache-dir "monai[ignite]" fire nibabel simpleITK
+RUN uv pip install -n "monai[ignite]==1.3.2" fire==0.6.0 nibabel==5.2.1
 
 # Clone the main branch of MHubAI/models
 ARG MHUB_MODELS_REPO
@@ -20,7 +20,7 @@ RUN buildutils/import_mhub_model.sh monai_prostate158 ${MHUB_MODELS_REPO}
 # Pull weights into the container
 ENV WEIGHTS_DIR=/app/models/monai_prostate158/bundle
 RUN mkdir -p $WEIGHTS_DIR
-RUN python3 -m monai.bundle download "prostate_mri_anatomy" --bundle_dir ${WEIGHTS_DIR}
+RUN uv run python -m monai.bundle download "prostate_mri_anatomy" --bundle_dir ${WEIGHTS_DIR}
 
 #define path to bundle root
 ENV BUNDLE_ROOT=/app/models/monai_prostate158/bundle/prostate_mri_anatomy

--- a/models/monai_prostate158/utils/Prostate158Runner.py
+++ b/models/monai_prostate158/utils/Prostate158Runner.py
@@ -8,14 +8,10 @@ Author: Cosmin Ciausu
 Email:  cciausu97@gmail.com
 -------------------------------------------------
 """
-# TODO: support multi-i/o and batch processing on multiple instances
 
-from typing import List, Optional
-import os, subprocess, shutil, glob, sys
-import SimpleITK as sitk, numpy as np
-from mhubio.core import Module, Instance, InstanceData, DataType, FileType, IO
-from mhubio.modules.runner.ModelRunner import ModelRunner
-import json
+import os, shutil, glob, sys
+import SimpleITK as sitk
+from mhubio.core import Module, Instance, InstanceData, FileType, IO
 
 @IO.Config('apply_center_crop', bool, True, the='flag to apply center cropping to input_image')
 class Prostate158Runner(Module):
@@ -45,8 +41,7 @@ class Prostate158Runner(Module):
         # define output folder (temp dir) and also override environment variable for nnunet
         out_dir = self.config.data.requestTempDir(label="monai-model-out")
        
-        bash_command = [sys.executable, 
-        "-m", "monai.bundle", "run", "evaluating"]
+        bash_command = [sys.executable, "-m", "monai.bundle", "run"]
         bash_command += ["--meta_file", os.path.join(os.environ['BUNDLE_ROOT'], "configs", "metadata.json")]
         bash_command += ["--config_file", os.path.join(os.environ['BUNDLE_ROOT'], "configs", "inference.json")]
         bash_command += ["--datalist", str(datalist)]

--- a/models/platipy/dockerfiles/Dockerfile
+++ b/models/platipy/dockerfiles/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install ffmpeg libsm6 libxext6  -y
 # Install nnunet and platipy
 RUN pip3 install --no-cache-dir \
   nnunet \
-  platipy[cardiac]==0.7.0
+  platipy[cardiac]==0.7.2
 
 # Import the MHub model definiton
 ARG MHUB_MODELS_REPO

--- a/models/pyradiomics/dockerfiles/Dockerfile
+++ b/models/pyradiomics/dockerfiles/Dockerfile
@@ -1,8 +1,11 @@
 FROM mhubai/base:latest
 
-# Install dependencies
-RUN pip3 install --no-cache-dir \
-  pyradiomics==3.0.1
+# Install pyradiomics 3.0.1 into a separate python 3.8 environment
+# NOTE: pyradiomics 3.1.0 does not provice a cli entrypoint
+# NOTE: pyradiomics 3.0.1 somehow doesn't correctly pick up the numpy build dependency. We use --no-build-isolation and manually install setuptools and numpy.
+RUN uv venv -p 3.8 .venv38 \
+ && uv pip install -p .venv38/ setuptools==74.1.2 numpy==1.24.4 \
+ && uv pip install -p .venv38/ --no-build-isolation pyradiomics==3.0.1
 
 # Import the MHub model definiton
 ARG MHUB_MODELS_REPO

--- a/models/pyradiomics/utils/PyRadiomicsRunner.py
+++ b/models/pyradiomics/utils/PyRadiomicsRunner.py
@@ -69,7 +69,7 @@ class PyRadiomicsRunner(Module):
     @IO.Instance()
     @IO.Input('image', 'nifti|nrrd:mod=ct|mr',  the='input image ct or mr scan')
     @IO.Inputs('segmentation', 'nifti|nrrd:mod=seg', the='input segmentation')
-    @IO.Output('results', '[d:roi].pyradiomics.csv', 'csv:features=pyradiomics', data='image', the='output csv file with the results')
+    @IO.Output('results', 'pyradiomics.csv', 'csv:features=pyradiomics', data='image', the='output csv file with the results')
     def task(self, instance: Instance, image: InstanceData, segmentation: InstanceDataCollection, results: InstanceData) -> None:
 
         # request temp dir for pyradiomics batch processing file
@@ -117,6 +117,7 @@ class PyRadiomicsRunner(Module):
         # build pyradiomics cli command
         #  pyradiomics <path/to/image> <path/to/segmentation> -o results.csv -f csv --param <path/to/params.yaml>
         cmd = [
+            'uv', 'run', '-p', '.venv38',
             'pyradiomics',
             pyr_bp_file,
             '-o', results.abspath,


### PR DESCRIPTION
- The base image now ships with uv 0.4.4
- The mhubio and segdb packages are now installed in a virtual environment using python 3.11 (bumped from 3.8)
- All dependency versions are fixed now (and will be moved into package dependencies with a future update)

- Some models require python 3.8, we created a new .venv38 environment with python 3.8 and installed the model dependencies there. The model logic is then outsourced into a cli script that is called from the Runner module.

- Future base images likely will contain updated versions of uv since uv is actively developed and receives frequent improvements and fixes.