### PR TITLE
msk_smit_lung_gtv, change num_workers=0 in run_segmentation.py 

### DIFF
--- a/models/msk_smit_lung_gtv/src/run_segmentation.py
+++ b/models/msk_smit_lung_gtv/src/run_segmentation.py
@@ -164,7 +164,7 @@ def main():
                                          base_dir=data_dir)
 
     val_org_ds = data.Dataset(data=test_files, transform=val_org_transforms)
-    val_org_loader = data.DataLoader(val_org_ds, batch_size=1, num_workers=4)
+    val_org_loader = data.DataLoader(val_org_ds, batch_size=1, num_workers=0)
 
     print('val data size is ', len(val_org_loader))
     post_transforms = Compose([


### PR DESCRIPTION
For data_loader low-shared memory instances. Should not affect runtime.